### PR TITLE
Arrow keys on search input do not move the page anymore

### DIFF
--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -52,16 +52,16 @@ export default function SearchBox({
         zoomOut();
         break;
       case "ArrowRight":
-        move("right");
+        if (!expanded) move("right");
         break;
       case "ArrowLeft":
-        move("left");
+        if (!expanded) move("left");
         break;
       case "ArrowUp":
-        move("up");
+        if (!expanded) move("up");
         break;
       case "ArrowDown":
-        move("down");
+        if (!expanded) move("down");
         break;
       default:
         break;


### PR DESCRIPTION
if (!expanded) then move